### PR TITLE
create dockerfile using efs-utils specs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM registry.ci.openshift.org/ocp/4.9:base
+
+# install deps
+RUN yum update -y && \
+    yum install --setopt=tsflags=nodocs -y nfs-utils stunnel python3 openssl util-linux which && \
+    yum clean all && rm -rf /var/cache/yum/*
+
+# create log file
+RUN mkdir -p /var/log/amazon/efs
+RUN touch /var/log/amazon/efs/mount.log
+
+# certs
+COPY ./dist/efs-utils.crt /etc/amazon/efs/efs-utils.crt
+RUN chmod 644 /etc/amazon/efs/efs-utils.crt
+COPY ./dist/efs-utils.conf /etc/amazon/efs/efs-utils.conf
+RUN chmod 444 /etc/amazon/efs/efs-utils.conf
+COPY ./src/mount_efs/__init__.py /sbin/mount.efs
+RUN chmod 755 /sbin/mount.efs
+COPY ./src/watchdog/__init__.py /usr/bin/amazon-efs-mount-watchdog
+RUN chmod 755 /usr/bin/amazon-efs-mount-watchdog


### PR DESCRIPTION
This PR adds docker file.

According to https://github.com/openshift/enhancements/pull/687, a base image is required to be used within https://github.com/openshift/aws-efs-csi-driver