### PR TITLE
[WIP] OCPBUGS-5041: Update to RHEL 9 base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/4.13:base
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-base-openshift-4.13
 
 # install deps
 RUN yum update -y && \


### PR DESCRIPTION
This PR should help testing a fix for OCPBUGS-5041, as RHEL 9 base image provides a newer stunnel version that potentially fixes the issue.

I won't be necessary to merge this if RHEL 9 becomes the default base image for OCP 4.13.

CC @openshift/storage 