### PR TITLE
OCPBUGS-18298: Add python3-botocore to the efs-util image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM registry.ci.openshift.org/ocp/4.14:base
 
 # install deps
 RUN yum update -y && \
-    yum install --setopt=tsflags=nodocs -y nfs-utils stunnel python3 openssl util-linux which && \
+    yum install --setopt=tsflags=nodocs -y nfs-utils stunnel python3 openssl util-linux which python3-botocore && \
     yum clean all && rm -rf /var/cache/yum/*
 
 # create log file


### PR DESCRIPTION
`python3-botocore` is needed as a fallback for resolving DNS names using `DescribeMountTargets` API call.

cc @openshift/storage 
