### PR TITLE
STOR-2478: UPSTREAM: <carry>: Add botocore and update reqs for RHEL 9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,13 @@
-FROM registry.ci.openshift.org/ocp/4.20:base-rhel9
+# Dockefile for OpenShift base image named "aws-efs-utils-base"
+#
+# The image contains:
+# - /sbin/mount.efs
+# - /usr/bin/amazon-efs-mount-watchdog
+# - /etc/amazon/*
+# - /var/log/amazon/efs/*
+# - botocore3 (to be able to use zonal EFS volumes)
 
-# install deps
-RUN yum update -y && \
-    yum install --setopt=tsflags=nodocs -y nfs-utils stunnel python3 openssl util-linux which && \
-    yum clean all && rm -rf /var/cache/yum/*
+FROM registry.ci.openshift.org/ocp/4.20:base-rhel9
 
 # create log file
 RUN mkdir -p /var/log/amazon/efs
@@ -18,3 +22,12 @@ COPY ./src/mount_efs/__init__.py /sbin/mount.efs
 RUN chmod 755 /sbin/mount.efs
 COPY ./src/watchdog/__init__.py /usr/bin/amazon-efs-mount-watchdog
 RUN chmod 755 /usr/bin/amazon-efs-mount-watchdog
+
+# Copy cachito / hermeto files used in the build pipeline. Copy an innocent file if the env. vars are not set.
+ENV REMOTE_SOURCES_SRC=${REMOTE_SOURCES:-"requirements.txt"}
+ENV REMOTE_SOURCES_DST=${REMOTE_SOURCES_DIR:-"/remote_sources_dir/"}
+COPY "$REMOTE_SOURCES_SRC" "$REMOTE_SOURCES_DST"
+
+# Install python dependencies (i.e. botocore).
+COPY requirements.txt.ocp install-python-deps-ocp.sh /src/
+RUN /src/install-python-deps-ocp.sh

--- a/install-python-deps-ocp.sh
+++ b/install-python-deps-ocp.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/bash
+
+# Install all efs-utils deps. Prefer RPMs, but in the end install the
+# remaining ones (= botocore) using pip.
+# Make sure pip installs from a local cache in the Red Hat build pipeline.
+# Everywhere else, let pip install from the internet.
+
+set -euxo pipefail
+
+yum update -y
+yum install --setopt=tsflags=nodocs -y nfs-utils stunnel python3 openssl util-linux which make python3-pip python3-jmespath python3-urllib3 python3-attrs python3-py python3-tomli python3-iniconfig python3-six.noarch python3-wheel
+yum clean all
+rm -rf /var/cache/yum/*
+
+REQS=/src/requirements.txt.ocp
+
+if [[ -v REMOTE_SOURCES ]]; then
+    echo "Red Hat build pipeline detected"
+    ls -lR "${REMOTE_SOURCES_DIR}/" # DEBUG
+
+    # Load cachito variables and requirements.txt.
+    # This re-configures pip to use the build system cache.
+    if [[ -d "${REMOTE_SOURCES_DIR}/cachito-gomod-with-deps" ]]; then
+        source "${REMOTE_SOURCES_DIR}/cachito-gomod-with-deps/cachito.env"
+        REQS="${REMOTE_SOURCES_DIR}/cachito-gomod-with-deps/app/requirements.txt.ocp"
+    fi
+fi
+
+# Finally, install all remaining requirements, ideally just botocore.
+# --no-build-isolation: use system setuptools and /bin/wheel from RPM packages.
+python3 -m pip install -r "${REQS}" --no-build-isolation

--- a/requirements.txt.ocp
+++ b/requirements.txt.ocp
@@ -1,0 +1,50 @@
+# OpenShift carry: requrements.txt tailored for OpenShift image build.
+
+# WARNING: to keep nr. of deps small, we remove most of unit-test dependencies!
+# `make test` won't work in the image build env.
+
+# All versions except botocore are set to the versions that are available in RHEL.
+
+attrs==20.3.0
+
+# botocore is not in RHEL9, download it from the internet (for local development) / cache (for real image builds).
+# botocore version in requirements.txt is too old (= requires too old urllib3 and docutils that are not in RHEL).
+# Using v1.34.140 from efs-utils-2.3.0 as a recent enough one that's fine with RHEL packages
+# and is at least used in some botocore release. Still, the version is quite arbitrary.
+botocore==1.34.140
+
+# RHEL Python 3.9 already has ConfigParser
+# configparser==3.5.0
+
+# coverage is not in RHEL and it's used only in tests.
+# coverage==4.5.4
+
+# RHEL Python 3.9 already supports enums
+# enum34==1.1.6
+
+# Used only for tests
+# flake8==3.7.9
+
+# Python 3.9 already support funcsig
+# funcsigs==1.0.2
+
+# Looks unused and is not in RHEL:
+# mccabe==0.6.1
+
+# Used only in tests:
+# mock==2.0.0
+# pbr==3.1.1
+# pluggy==0.13.0
+
+py==1.10.0
+
+# Used only in tests
+# pycodestyle==2.5.0
+# pyflakes==2.1.1
+# pytest==4.6.7
+# pytest-cov==2.8.1
+# pytest-html==1.19.0
+# pytest-metadata==1.7.0
+# pytest-mock==1.11.2
+
+six==1.15.0


### PR DESCRIPTION
Install botocore during the image build, using a newly introduced `prepare-image-ocp.sh` script.
    
* Install efs-utils + botocore python dependencies that we have in RHEL.
* **Heavily edit requirements.txt (as `requirements.txt.ocp`)**
    * Set version numbers to the versions available in RHEL. **Note that before this PR we did not have these dependencies installed at all and efs-utils still somehow worked.**
    * Remove lot of test dependencies. We don't have them in RHEL and we won't be able to run the unit test in our CI! Again, we did not have these deps installed before this PR and efs-utils worked.
    * Set botocore version to something that works with RHEL python. It's quite newer than efs-utils wants.

- During the image build, use env. vars + scripts from the Red Hat build system and use botocore from the build system cache. Controlled by `$REMOTE_SOURCES` env var, which is set only in ART builds.
- During any other build (e.g. in CI or on local machine), just download botocore from the internet.


The goal is to download only botocore from the internet (or the build system cache), everything else is covered by RPMs:
```
+ python3 -m pip install -r /src/requirements.txt.ocp --no-build-isolation
Requirement already satisfied: attrs==20.3.0 in /usr/lib/python3.9/site-packages (from -r /src/requirements.txt.ocp (line 8)) (20.3.0)
Collecting botocore==1.34.140
  Downloading botocore-1.34.140-py3-none-any.whl (12.4 MB)
Requirement already satisfied: py==1.10.0 in /usr/lib/python3.9/site-packages (from -r /src/requirements.txt.ocp (line 39)) (1.10.0)
Requirement already satisfied: six==1.15.0 in /usr/lib/python3.9/site-packages (from -r /src/requirements.txt.ocp (line 50)) (1.15.0)
Requirement already satisfied: python-dateutil<3.0.0,>=2.1 in /usr/lib/python3.9/site-packages (from botocore==1.34.140->-r /src/requirements.txt.ocp (line 14)) (2.8.1)
Requirement already satisfied: urllib3<1.27,>=1.25.4 in /usr/lib/python3.9/site-packages (from botocore==1.34.140->-r /src/requirements.txt.ocp (line 14)) (1.26.5)
Requirement already satisfied: jmespath<2.0.0,>=0.7.1 in /usr/lib/python3.9/site-packages (from botocore==1.34.140->-r /src/requirements.txt.ocp (line 14)) (0.9.4)
Installing collected packages: botocore
Successfully installed botocore-1.34.140
```