### PR TITLE
OCPBUGS-76394: Install python3-dateutil

### DIFF
--- a/install-python-deps-ocp.sh
+++ b/install-python-deps-ocp.sh
@@ -8,7 +8,7 @@
 set -euxo pipefail
 
 yum update -y
-yum install --setopt=tsflags=nodocs -y nfs-utils stunnel python3 openssl util-linux which make python3-pip python3-jmespath python3-urllib3 python3-attrs python3-py python3-tomli python3-iniconfig python3-six.noarch python3-wheel
+yum install --setopt=tsflags=nodocs -y nfs-utils stunnel python3 openssl util-linux which make python3-pip python3-jmespath python3-urllib3 python3-attrs python3-py python3-tomli python3-iniconfig python3-six.noarch python3-wheel python3-dateutil
 yum clean all
 rm -rf /var/cache/yum/*
 


### PR DESCRIPTION
Part of the fix for OCPBUGS-76394

Currently python3-dateutil is included in the base image because subscription-manager pulls it in as a dep, however we aim to remove subscription-manager from the base image and therefore need to explicitly install it. One would expect that pip would simply install it but that doesn't seem to be working in Konflux.